### PR TITLE
Add toggle `renderChildBeforeInit` for isomophic project and SEO purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ visualization needs to be updated in order to fit into container.
 </ContainerDimensions>    
 ```
 
+* Use the `renderChildBeforeInit` to make the child rendered before initialize (for isomophic project and SEO purpose). The default behavior is rendering an empty `div` before initialize.
+
+```jsx
+<ContainerDimensions renderChildBeforeInit={true}>
+    <MyComponent/>
+</ContainerDimensions>    
+```
+
 ## How is it different from ...
 
 *It does not create a new element in the DOM but relies on the `parentNode` which must be present.* 

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,8 @@ import invariant from 'invariant'
 export default class ContainerDimensions extends Component {
 
     static propTypes = {
-        children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired
+        children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
+        renderChildBeforeInit: PropTypes.bool
     }
 
     constructor() {
@@ -40,7 +41,7 @@ export default class ContainerDimensions extends Component {
     render() {
         invariant(this.props.children, 'Expected children to be one of function or React.Element')
 
-        if (!this.state.initiated) {
+        if (!this.state.initiated && !this.props.renderChildBeforeInit) {
             return <div />
         }
         if (typeof this.props.children === 'function') {

--- a/tests/index.js
+++ b/tests/index.js
@@ -68,7 +68,7 @@ describe('react-container-dimensions', () => {
         }, 0)
     })
 
-    it('should initially render an empty placeholder', () => {
+    it('should initially render an empty placeholder by default', () => {
         const wrapper = mount(
             <ContainerDimensions>
                 <MyComponent />
@@ -87,6 +87,20 @@ describe('react-container-dimensions', () => {
         })
 
         expect(wrapper.find(MyComponent).length).to.eq(1)
+    })
+
+    it('should initially render the children when renderChildBeforeInit toggle is on', () => {
+        const wrapper = mount(
+            <ContainerDimensions renderChildBeforeInit={true}>
+                <MyComponent />
+            </ContainerDimensions>
+        )
+        wrapper.setState({
+            initiated: false
+        })
+
+        expect(wrapper.find(MyComponent)).to.have.length(1)
+        expect(wrapper.find(MyComponent)).to.have.prop('initiated', false)
     })
 
     it('should pass width and height as props to its children', () => {
@@ -148,6 +162,6 @@ describe('react-container-dimensions', () => {
             ' class="erd_scroll_detection_container' +
             ' erd_scroll_detection_container_animation_active" style="visibility: hidden;' +
             ' display: inline; width: 0px; height: 0px; z-index: -1; overflow:' +
-            ' hidden;"></div></h1>')
+            ' hidden; margin: 0px; padding: 0px;"></div></h1>')
     })
 })


### PR DESCRIPTION
For SEO purpose, sometimes the child component has to be rendered so that the robot can get the info from server rendered Html. So I add a toggle to give us an option. By default, the container-dimensions would still render an empty `div` before initialize.
