### PR TITLE
Pass all values of getBoundingClientRect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.0
+
+- Pass all values of getBoundingClientRect, not just `width` and `height`. (#6)
+
 # 1.2.0
 
 - Added React 15 to a semver range for peerDependencies (#3)

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ It is especially useful when you create components with dimensions that change o
 time and you want to explicitely pass the container dimensions to the children. For example, SVG 
 visualization needs to be updated in order to fit into container.
 
+It uses [`getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) and passes values for all `top`, `right`, `bottom`, `left`, `width`, `height` CSs attributes down the tree.
+
 ## Usage
 
-* Wrap your existing components. Children component will recieve `width` and `height` as props. 
+* Wrap your existing components. Children component will recieve `top`, `right`, `bottom`, `left`, `width`, `height` as props. 
 
 ```jsx
 <ContainerDimensions>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-container-dimensions",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Wrapper component that detects element resize and passes new dimensions down the tree. Based on [element-resize-detector](https://github.com/wnr/element-resize-detector)",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,11 @@ export default class ContainerDimensions extends Component {
         children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired
     }
 
+    static getDomNodeDimensions(node) {
+        const { top, right, bottom, left, width, height } = node.getBoundingClientRect()
+        return { top, right, bottom, left, width, height }
+    }
+
     constructor() {
         super()
         this.state = {
@@ -29,11 +34,10 @@ export default class ContainerDimensions extends Component {
     }
 
     onResize() {
-        const clientRect = this.parentNode.getBoundingClientRect()
+        const clientRect = ContainerDimensions.getDomNodeDimensions(this.parentNode)
         this.setState({
             initiated: true,
-            width: clientRect.width,
-            height: clientRect.height
+            ...clientRect
         })
     }
 


### PR DESCRIPTION
Pass all values of getBoundingClientRect, not only `width` and `height`.

List of supported properties: `top`, `right`, `bottom`, `left`, `width`, `height`.