### PR TITLE
Uninstall the listener on componentWillUnmount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export default class ContainerDimensions extends Component {
     }
 
     componentWillUnmount() {
-        this.elementResizeDetector.removeListener(this.parentNode, this.onResize)
+        this.elementResizeDetector.uninstall(this.parentNode)
     }
 
     onResize() {


### PR DESCRIPTION
Uninstall the listener on componentWillUnmount to ensure the element-resize-detector is correctly set up on next mount.

Fix #12.