### PR TITLE
Remove React.Proptypes and add in the new 'prop-types' module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "homepage": "https://github.com/okonet/react-container-dimensions#readme",
   "dependencies": {
     "element-resize-detector": "^1.1.10",
-    "invariant": "^2.2.2"
+    "invariant": "^2.2.2",
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
@@ -79,7 +80,7 @@
     "react-addons-test-utils": "^15.4.1",
     "react-dom": "^15.4.1",
     "rimraf": "^2.5.3",
-    "sinon": "^1.17.7",
-    "semantic-release": "^6.3.2"
+    "semantic-release": "^6.3.2",
+    "sinon": "^1.17.7"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Children, Component, PropTypes } from 'react'
+import React, { Children, Component } from 'react'
+import PropTypes from 'prop-types'
 import ReactDOM from 'react-dom'
 import elementResizeDetectorMaker from 'element-resize-detector'
 import invariant from 'invariant'


### PR DESCRIPTION
Proptypes imported from React are being depricated and are now moved into the new 'prop-types' npm module.  This will prevent the warning in react 15.5.X 