### PR TITLE
Adds a new updateOffsetOnChange prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,21 @@ import invariant from 'invariant'
 export default class ContainerDimensions extends Component {
 
   static propTypes = {
-    children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired
+    children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
+    updateOnOffsetChange: PropTypes.bool
+  }
+
+  static defaultProps = {
+    updateOnOffsetChange: false
   }
 
   static getDomNodeDimensions(node) {
     const { top, right, bottom, left, width, height } = node.getBoundingClientRect()
     return { top, right, bottom, left, width, height }
+  }
+
+  static areRectsEqual(rect1, rect2) {
+    return ['top', 'right', 'bottom', 'left', 'width', 'height'].every(attr => rect1[attr] === rect2[attr])
   }
 
   constructor() {
@@ -30,6 +39,7 @@ export default class ContainerDimensions extends Component {
       callOnAdd: false
     })
     this.elementResizeDetector.listenTo(this.parentNode, this.onResize)
+
     this.onResize()
   }
 
@@ -39,10 +49,17 @@ export default class ContainerDimensions extends Component {
 
   onResize() {
     const clientRect = ContainerDimensions.getDomNodeDimensions(this.parentNode)
-    this.setState({
-      initiated: true,
-      ...clientRect
-    })
+
+    if (ContainerDimensions.areRectsEqual(this.state, clientRect) === false) {
+      this.setState({
+        initiated: true,
+        ...clientRect
+      })
+    }
+
+    if (this.props.updateOnOffsetChange) {
+      window.requestAnimationFrame(this.onResize)
+    }
   }
 
   render() {

--- a/testSetup.js
+++ b/testSetup.js
@@ -4,10 +4,12 @@ global.document = jsdom('<!doctype html><html><body><div id="root"></div></body>
 global.window = document.defaultView
 
 Object.keys(document.defaultView).forEach((property) => {
-    if (typeof global[property] === 'undefined') {
-        global[property] = document.defaultView[property]
-    }
+  if (typeof global[property] === 'undefined') {
+    global[property] = document.defaultView[property]
+  }
 })
 
 global.navigator = { userAgent: 'node.js' }
 global.documentRef = document
+
+global.window.requestAnimationFrame = () => {}

--- a/tests/index.js
+++ b/tests/index.js
@@ -210,4 +210,30 @@ describe('react-container-dimensions', () => {
 
     window.requestAnimationFrame.restore()
   })
+
+  it('should only update state when the bounding rect has changed', () => {
+    const wrapper = mount(
+      <ContainerDimensions>
+        <MyComponent />
+      </ContainerDimensions>
+      , { attachTo: document.getElementById('root') })
+
+    const el = wrapper.get(0)
+    spy(el, 'setState')
+
+    el.onResize()
+    expect(el.setState.called).to.be.false
+
+    const newRect = { top: 10, right: 0, bottom: 0, left: 0, width: 0, height: 0 }
+    stub(ContainerDimensions, 'getDomNodeDimensions').callsFake(() => newRect)
+
+    el.onResize()
+    expect(el.setState.called).to.be.true
+    expect(el.setState.args[0][0]).to.deep.equal({
+      ...newRect,
+      initiated: true
+    })
+
+    ContainerDimensions.getDomNodeDimensions.restore()
+  })
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -3,9 +3,10 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { spy, stub } from 'sinon'
 import chai, { expect } from 'chai'
+import chaiEnzyme from 'chai-enzyme'
 import ContainerDimensions from '../src/index'
 
-chai.use(require('chai-enzyme')())
+chai.use(chaiEnzyme())
 const MyComponent = ({ width, height }) => <span>{width}, {height}</span> // eslint-disable-line
 
 describe('react-container-dimensions', () => {
@@ -52,7 +53,7 @@ describe('react-container-dimensions', () => {
   xit('calls onResize when parent has been resized', (done) => {
     spy(ContainerDimensions.prototype, 'onResize')
     const wrapper = mount(
-      <div ref="node" id="node" style={{ width: 10 }}>
+      <div id="node" style={{ width: 10 }}>
         <ContainerDimensions>
           <MyComponent />
         </ContainerDimensions>
@@ -193,5 +194,20 @@ describe('react-container-dimensions', () => {
       </h1>
     )
     expect(wrapper.html()).to.contain('<h1><span width="0" height="0">Test</span>')
+  })
+
+  it('should call onResize on every frame when updateOnOffsetChange is true', () => {
+    spy(window, 'requestAnimationFrame')
+
+    const wrapper = mount(
+      <ContainerDimensions updateOnOffsetChange>
+        <MyComponent />
+      </ContainerDimensions>
+    )
+
+    expect(window.requestAnimationFrame.called).to.be.true
+    expect(window.requestAnimationFrame.args[0][0]).to.equal(wrapper.get(0).onResize)
+
+    window.requestAnimationFrame.restore()
   })
 })


### PR DESCRIPTION
As discussed in #24, the `top` and `left` passed on to children components are not updated when they are changed, for instance when scrolling the page.

This is a quite naive solution, where we basically check `getBoundingClientRect()` on every frame. I couldn't come up with a reasonable alternative, since there are a ton of ways an element's offset can be changed. If you have an idea, that'd be great!

If we implement this, it should probably come with a friendly warning about the implementation.